### PR TITLE
Update ciac.m

### DIFF
--- a/ciac.m
+++ b/ciac.m
@@ -171,16 +171,16 @@ fprintf('\n')
 %finding positions
 
 %%% onset of artifact
-pos1=find(ALLEEG(1).times==t1);
-pos2=find(ALLEEG(1).times==t2);
+pos1=min(find(ALLEEG(1).times>=t1)); 
+pos2=min(find(ALLEEG(1).times>=t2)); 
 
 %%% offset of artifact
-pos3=find(ALLEEG(1).times==t3);
-pos4=find(ALLEEG(1).times==t4);
+pos3=max(find(ALLEEG(1).times<=t3));
+pos4=max(find(ALLEEG(1).times<=t4));
 
 %%% N1-P2 time window AEP
-pos_in=find(ALLEEG(1).times==tin);
-pos_fin=find(ALLEEG(1).times==tfin);
+pos_in=min(find(ALLEEG(1).times>=tin));
+pos_fin=max(find(ALLEEG(1).times<=tfin));
 
 
 if Cz<1


### PR DESCRIPTION
Lines 173 to 183 was searching for the indices of ALLEEG(1).times matching particular instants, e.g. t1, t2, etc.. 
In my case (sf=256 Hz), my sampled times did not fall exactly on integer numbers such as the default window [80 250] ms
So, I've edited these 6 lines to search for the closest times to these instants. I looked slightly beyond t1, t2, tin and slightly before t3, t4, and tfin (if an exact match could not be found).